### PR TITLE
Configures working spec setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'puppetlabs_spec_helper', '>= 0.8.2'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
 gem 'coveralls', require: false
+gem 'rspec-puppet-facts'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,25 +1,22 @@
 require 'spec_helper'
 describe 'fcoe' do
 
-  let :default_params do
-    {
-      :fcoe_packages     => '["fcoe-utils","lldpad"]',
-      :fcoe_service      => '["fcoe","lldpad"]',
-      :network_service   => 'network',
-    }
-  end
-  describe 'os-dependent items' do
-    context "on RedHat based systems" do
-      let :default_facts do
-        {
-          :os                     => { :family => 'RedHat', :release => { :major => '7', :minor => '1', :full => '7.1.1503' } },
-          :kernel                 => 'Linux',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge({
+          # Any required changed facts
+        })
       end
-      let :params do default_params end
-      let :facts do default_facts end
+
       it { is_expected.to contain_class("fcoe") }
+
+      it { is_expected.to contain_package("fcoe-utils") }
+      it { is_expected.to contain_package("lldpad") }
+      it { is_expected.to contain_service("fcoe") }
+      it { is_expected.to contain_service("lldpad") }
+      it { is_expected.to contain_service("network") }
     end
   end
+
 end

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -6,7 +6,7 @@ describe 'fcoe::interface' do
   let :title do
     'fcoe-eth0'
   end
-  let :default_params do
+  let :params do
     {
       :fcoe_interface => 'eth0',
       :fcoe_enable    => 'yes',
@@ -17,17 +17,14 @@ describe 'fcoe::interface' do
       :fcoe_mtu       => '9000',
     }
   end
-  describe 'os-dependent items' do
-    context "on RedHat based systems" do
-      let :default_facts do
-        {
-          :os                     => { :family => 'RedHat', :release => { :major => '7', :minor => '1', :full => '7.1.1503' } },
-          :kernel                 => 'Linux',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge({
+          # Any required changed facts
+        })
       end
-      let :params do default_params end
-      let :facts do default_facts end
+
       it { is_expected.to contain_class("fcoe") }
       it { is_expected.to contain_class("fcoe::params") }
       it do
@@ -35,8 +32,18 @@ describe 'fcoe::interface' do
           'owner'   => 'root',
           'group'   => 'root',
           'mode'    => '0644',
+          'content' => /DEVICE=eth0/,
+        )
+      end
+      it do
+        is_expected.to contain_file("cfg-eth0").with(
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'content' => /MODE="fabric"/,
         )
       end
     end
   end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
+
+at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
* Use rspec-puppet-facts to iteratively test all supported platforms
* Add test coverage task to show test coverage of Puppet code
* Add specs to test for all defaults, such as required packages and services
* Adds content rspec regex tests for defined types